### PR TITLE
Adding quarantine folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./data/queue:/data/av/queue
       - ./data/ok:/data/av/ok
       - ./data/nok:/data/av/nok
+    #  - ./data/quarantine:/data/av/quarantine
     networks:
       - avnetwork
 


### PR DESCRIPTION
## Summary of the changes you propose

Added quarantine folder to docker-compose.yml with the line commented out.  I commented it out to not interfere with anyone already using something else.  But I am adding it so people will know the proper path if they do want to include it in their config.

## Rationale for these changes

Helps people understand how to implement the feature.   This change identifies the path where the quarantined files are stored inside the container so that it can be mapped to an external volume easier.
