### PR TITLE
Fix for issue #6

### DIFF
--- a/assets/bin/scanner.sh
+++ b/assets/bin/scanner.sh
@@ -4,8 +4,8 @@ if (( ${#files} ))
 then
     printf "Found files to process\n"
     for file in "/data/av/queue"/* ; do
-        filename=`basename $file`
-        mv -f $file "/data/av/scan/${filename}"
+        filename=`basename "$file"`
+        mv -f "$file" "/data/av/scan/${filename}"
         printf "Processing /data/av/scan/${filename}\n"
         /usr/local/bin/scanfile.sh > /data/av/scan/info 2>&1
         if [ -e "/data/av/scan/${filename}" ]


### PR DESCRIPTION
#6 

## Summary of the changes you propose

Padding file variable with quotes to prevent issues with unescaped spaces in the file name.

## Rationale for these changes

Fix for files not being moved out of queue when spaces are in the name.
